### PR TITLE
added ability to only run pr preview on certian branches

### DIFF
--- a/.github/workflows/pr_deploy.yaml
+++ b/.github/workflows/pr_deploy.yaml
@@ -2,6 +2,9 @@ name: Pr - Preview
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+    branches:
+      - "bugfix/**"
+      - "feature/**"
 jobs:
   dev-pr-create-s3:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_deploy.yaml
+++ b/.github/workflows/pr_deploy.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
     branches:
-      - "bugfix/**"
+      - "fix/**"
       - "feat/**"
 jobs:
   dev-pr-create-s3:

--- a/.github/workflows/pr_deploy.yaml
+++ b/.github/workflows/pr_deploy.yaml
@@ -4,7 +4,7 @@ on:
     types: [opened, reopened, synchronize]
     branches:
       - "bugfix/**"
-      - "feature/**"
+      - "feat/**"
 jobs:
   dev-pr-create-s3:
     runs-on: ubuntu-latest

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -1,13 +1,14 @@
 name: deploy to staging environment
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - redesign2023
 jobs:
   staging:
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
     environment: staging
-    if: github.ref == 'refs/heads/redesign2023'
 
     steps:
       - name: checkout


### PR DESCRIPTION
Changes made :
- PR preview workflow now only runs on branches specified as "bugfix/*<branch name>*" or "feature/*<branch name>*". Anything which is not directly changing the content of the website (e.g. workflow or docker changes) should not have this naming convention for the branch, therefore won't unnecessarily create a new s3 bucket. 
- Staging workflow will now run on every push to "redesign2023" instead of a dispatch event. 
 