### PR TITLE
Removed tag pair linter

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -11,7 +11,7 @@
   "attr-whitespace": true,
   "alt-require": true,
   "input-requires-lable": true,
-  "tag-pair": true,
+  "tag-pair": false,
   "tagname-lowercase": true,
   "tagname-specialchars": true,
   "src-not-empty": true,


### PR DESCRIPTION
Ruby tags give issues with matching pairs, so let's ignore this rule for now.