### PR TITLE
Removed min and max width in info section

### DIFF
--- a/assets/style/home.css
+++ b/assets/style/home.css
@@ -377,8 +377,6 @@
 .news,
 .packages,
 .about-bioconductor {
-  max-width: 24rem;
-  min-width: 24rem;
   padding: 2rem;
   border-radius: 0.5rem;
   background-color: white;

--- a/assets/style/home.css
+++ b/assets/style/home.css
@@ -372,6 +372,8 @@
   grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
   background-color: inherit;
   gap: 2rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
 }
 
 .news,

--- a/layouts/components/homepage/info.html
+++ b/layouts/components/homepage/info.html
@@ -4,9 +4,9 @@
       <img src="images/icons/svgs/DNA.svg" alt="DNA" />
       <h2 class="format-bold">About Bioconductor</h2>
       <p class="text-large">
-        Bioconductor uses the R statistical programming language, and is
-        open source and open development. It has two releases each year, and
-        an active user community.
+        Bioconductor uses the R statistical programming language, and is open
+        source and open development. It has two releases each year, and an
+        active user community.
       </p>
       <p class="text-large">
         Bioconductor is also available as
@@ -17,9 +17,20 @@
       <a class="brand-border-button" href="/about/">
         <span class="span-brand format-bold">
           More about Bioconductor
-          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="15" viewBox="0 0 14 15" fill="none">
-            <path d="M5.25 3.66665L9.33333 7.74998L5.25 11.8333" stroke="#3792AD" stroke-width="2.2"
-              stroke-linecap="round" stroke-linejoin="round" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="15"
+            viewBox="0 0 14 15"
+            fill="none"
+          >
+            <path
+              d="M5.25 3.66665L9.33333 7.74998L5.25 11.8333"
+              stroke="#3792AD"
+              stroke-width="2.2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
           </svg>
         </span>
       </a>
@@ -30,18 +41,33 @@
       <img src="images/icons/svgs/Packages.svg" alt="Package-polygons" />
       <h2>Packages</h2>
       <p class="text-large">
-        Discover 2230 software packages available in Bioconductor release
-        3.17.
+        Discover 2230 software packages available in Bioconductor release 3.17.
       </p>
-      <a class="text-large format-underline">Download package Vignettes</a>
+      <a class="text-large format-underline" href="/help/package-vignettes/"
+        >Download package Vignettes</a
+      >
     </div>
     <div class="info-section-button-padding">
-      <a class="brand-border-button" href="/packages/release/BiocViews.html#___Software">
+      <a
+        class="brand-border-button"
+        href="/packages/release/BiocViews.html#___Software"
+      >
         <span class="span-brand format-bold">
           See all packages
-          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="15" viewBox="0 0 14 15" fill="none">
-            <path d="M5.25 3.66665L9.33333 7.74998L5.25 11.8333" stroke="#3792AD" stroke-width="2.2"
-              stroke-linecap="round" stroke-linejoin="round" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="15"
+            viewBox="0 0 14 15"
+            fill="none"
+          >
+            <path
+              d="M5.25 3.66665L9.33333 7.74998L5.25 11.8333"
+              stroke="#3792AD"
+              stroke-width="2.2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
           </svg>
         </span>
       </a>
@@ -51,32 +77,61 @@
     <h2>News</h2>
     <p class="news-item text-large">
       Bioconductor
-      <a class="text-large format-underline">Bioc 3.17</a> Released
-    </p>
-    <p class="news-item text-large">
-      Bioconductor <a class="text-large format-underline">Community Blog</a>
-    </p>
-    <p class="news-item text-large">
-      Bioconductor
-      <a class="text-large format-underline">browsable code </a>now
-      available
-    </p>
-    <p class="news-item text-large">
-      See our <a class="text-large format-underline">google calendar </a>for
-      events, conferences, meetings, forums, etc
+      <a class="text-large format-underline" href="/news/bioc_3_17_release"
+        >Bioc 3.17</a
+      >
+      Released
     </p>
     <p class="news-item text-large">
       Bioconductor
-      <a class="text-large format-underline">F1000 Research Channel </a>is
-      available.
+      <a
+        class="text-large format-underline"
+        href="https://bioconductor.github.io/biocblog"
+        >Community Blog</a
+      >
+    </p>
+    <p class="news-item text-large">
+      Bioconductor
+      <a
+        class="text-large format-underline"
+        href="https://code.bioconductor.org/"
+        >browsable code </a
+      >now available
+    </p>
+    <p class="news-item text-large">
+      See our
+      <a
+        class="text-large format-underline"
+        href="https://bioconductor.org/help/events/"
+        >google calendar </a
+      >for events, conferences, meetings, forums, etc
+    </p>
+    <p class="news-item text-large">
+      Bioconductor
+      <a
+        class="text-large format-underline"
+        href="http://f1000research.com/channels/bioconductor"
+        >F1000 Research Channel </a
+      >is available.
     </p>
     <div class="info-section-button-padding">
       <a class="brand-border-button" href="/news/">
         <span class="span-brand format-bold">
           See all News
-          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="15" viewBox="0 0 14 15" fill="none">
-            <path d="M5.25 3.66665L9.33333 7.74998L5.25 11.8333" stroke="#3792AD" stroke-width="2.2"
-              stroke-linecap="round" stroke-linejoin="round" />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="15"
+            viewBox="0 0 14 15"
+            fill="none"
+          >
+            <path
+              d="M5.25 3.66665L9.33333 7.74998L5.25 11.8333"
+              stroke="#3792AD"
+              stroke-width="2.2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
           </svg>
         </span>
       </a>


### PR DESCRIPTION
Homepage info section width is not responsive when adjusting the screen size, it fills the screen when in mobile 
- it now has a margin when in mobile 