### PR TITLE
Added citation styling

### DIFF
--- a/assets/style/pages/packages.css
+++ b/assets/style/pages/packages.css
@@ -115,6 +115,13 @@ ul.ui-autocomplete li::before {
   content: none;
 }
 
+.bioc-citation {
+  background-color: var(--neutral-n50);
+  border: 1px solid var(--neutral-n75);
+  padding: 1rem 1rem 0;
+  margin: 0.5rem 0 1rem;
+}
+
 @media (max-device-width: 1250px), (max-width: 1250px) {
   .biocViewsTreeContainer {
     display: flex;


### PR DESCRIPTION
Added styling for the citation block. Closes #173

Looks like:

![image](https://github.com/nearform/bioconductor.org/assets/52213009/34f7a51a-7778-4491-bbf4-8da23521ce4b)

![image](https://github.com/nearform/bioconductor.org/assets/52213009/dad1daaf-83ec-41d8-bafe-3942f356be65)

![Screenshot 2023-08-11 at 11 08 27](https://github.com/nearform/bioconductor.org/assets/52213009/f850ae6e-fef0-4631-879c-ab67e29c436d)

